### PR TITLE
Update the requirements file for OSX Mavericks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 ipython>=0.13.2
 python-memcached
-MySQL-python==1.2.4
+MySQL-python==1.2.5
 Django==1.4.5
 South==0.8.1
 Pillow==2.1.0
 decorator==3.4.0
-django-debug-toolbar>=0.9.4
+django-debug-toolbar==0.9.4
 django-crispy-forms==1.3.2
 django-grappelli==2.4.5
 django-compressor==1.3


### PR DESCRIPTION
Update the requirement as MySQL-python version is not compatible with the latest OSX Mavericks and fixed the version of django-debug-toolbar at 0.9.4 as later versions are not compatible with Django 1.4.5.
